### PR TITLE
fix[3618]: change sortOrder to fix router infinite loop

### DIFF
--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -6,7 +6,7 @@
                 <item name="stylarouter" xsi:type="array">
                     <item name="class" xsi:type="string">Styla\Connect2\Controller\Router</item>
                     <item name="disable" xsi:type="boolean">false</item>
-                    <item name="sortOrder" xsi:type="string">22</item>
+                    <item name="sortOrder" xsi:type="string">30</item>
                 </item>
             </argument>
         </arguments>


### PR DESCRIPTION
https://trello.com/c/RbImcndu/3618-hallhuber-m2-plugin-error-front-controller-reached-100-router-match-iterations