### PR TITLE
Fix issue where VirtualType overwrites base class

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -10,11 +10,11 @@
     <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
         <arguments>
             <argument name="collections" xsi:type="array">
-                <item name="styla_connect2_magazine_listing_data_source" xsi:type="string">Styla\Connect2\Model\ResourceModel\Magazine\Collection</item>
+                <item name="styla_connect2_magazine_listing_data_source" xsi:type="string">Styla\Connect2\Model\ResourceModel\Magazine\CollectionResult</item>
             </argument>
         </arguments>
     </type>
-    <virtualType name="Styla\Connect2\Model\ResourceModel\Magazine\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
+    <virtualType name="Styla\Connect2\Model\ResourceModel\Magazine\CollectionResult" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
         <arguments>
             <argument name="mainTable" xsi:type="string">styla_magazine</argument>
             <argument name="resourceModel" xsi:type="string">Styla\Connect2\Model\ResourceModel\Magazine</argument>


### PR DESCRIPTION
On 2.2.9 Styla returned an error:
`FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught TypeError: Argument 5 passed to Styla\Connect2\Model\ResourceModel\Magazine\Collection\Interceptor::__construct() must implement interface Magento\Framework\DB\Adapter\AdapterInterface or be null, string given, called in vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php on line 111 and defined in generated/code/Styla/Connect2/Model/ResourceModel/Magazine/Collection/Interceptor.php`

This was caused by the di.xml overwriting the Styla/Connect2/Model/ResourceModel/Magazine/Collection class with a VirtualType with extra arguments.