### PR TITLE
Remove unused getId and getName calls from Api Model

### DIFF
--- a/Model/Api/StylaCategory.php
+++ b/Model/Api/StylaCategory.php
@@ -27,14 +27,4 @@ class StylaCategory extends Category implements StylaCategoryTreeInterface
         return $this->getData('image');
     }
 
-    public function getId()
-    {
-        // TODO: Implement getId() method.
-    }
-
-    public function getName()
-    {
-        // TODO: Implement getName() method.
-    }
-
 }


### PR DESCRIPTION
As asked by Styla we've researched an issue with an API call; We've fond the following that is causing this issue:

These unwritten functions caused the API call for /rest/V1/styla_category to return NULL results. 

Because this model does get used as a basis for the API of the Category of Styla and wants to return the results of functions that don't return any result while the parent it's overwriting do return results.

In the future: Please check your code an/or let a senior review before putting things like this in a release. What would also help is to write some tests so an automated system could already find this exact issue before releasing.