### PR TITLE
CMS-584 Support Magento2 v2.4.5

### DIFF
--- a/Model/Styla/Api.php
+++ b/Model/Styla/Api.php
@@ -47,7 +47,6 @@ class Api
      */
     protected $_apiConnectionOptions = [
         CURLOPT_RETURNTRANSFER => 1,
-        CURLOPT_HTTPHEADER,
         [
             'Accept: application/json',
         ],


### PR DESCRIPTION
[CMS-584 - Update the Magento2 plugin to support Magento2 v2.4.5](https://styla.atlassian.net/browse/CMS-584)

> We changed the following function and removed the second argument (`CURLOPT_HTTPHEADER`):
> ```
> protected $_apiConnectionOptions =
> [ CURLOPT_RETURNTRANSFER => 1, CURLOPT_HTTPHEADER, [ 'Accept: application/json', ], ];
> ```
> Now the backend connection initialization is working and we have successfully loaded the magazine pages.
> I think maybe the above is an incompatibility with PHP 8.1 which the latest Magento 2 build requires.

### Acceptance Criteria
- use this fix on our Magento2 plugin repo