### PR TITLE
CMS-1484 Fix to support magento v2.4.7

### DIFF
--- a/Model/Api/ProductRepository.php
+++ b/Model/Api/ProductRepository.php
@@ -100,7 +100,6 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
     /**
      *
      * @param \Magento\Catalog\Model\ProductFactory                               $productFactory
-     * @param \Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper $initializationHelper
      * @param \Magento\Catalog\Api\Data\ProductSearchResultsInterfaceFactory      $searchResultsFactory
      * @param \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory      $collectionFactory
      * @param \Magento\Framework\Api\SearchCriteriaBuilder                        $searchCriteriaBuilder
@@ -125,7 +124,6 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
      */
     public function __construct(
         \Magento\Catalog\Model\ProductFactory $productFactory,
-        \Magento\Catalog\Controller\Adminhtml\Product\Initialization\Helper $initializationHelper,
         \Magento\Catalog\Api\Data\ProductSearchResultsInterfaceFactory $searchResultsFactory,
         \Magento\Catalog\Model\ResourceModel\Product\CollectionFactory $collectionFactory,
         \Magento\Framework\Api\SearchCriteriaBuilder $searchCriteriaBuilder,
@@ -171,7 +169,7 @@ class ProductRepository extends \Magento\Catalog\Model\ProductRepository
         $this->eventManager                    = $eventManager;
         $this->converterHelper                 = $converterHelper;
 
-        return parent::__construct($productFactory, $initializationHelper, $searchResultsFactory, $collectionFactory, $searchCriteriaBuilder, $attributeRepository, $resourceModel, $linkInitializer, $linkTypeProvider, $storeManager, $filterBuilder, $metadataServiceInterface, $extensibleDataObjectConverter, $optionConverter, $fileSystem, $contentValidator, $contentFactory, $mimeTypeExtensionMap, $imageProcessor, $extensionAttributesJoinProcessor);
+        return parent::__construct($productFactory, $searchResultsFactory, $collectionFactory, $searchCriteriaBuilder, $attributeRepository, $resourceModel, $linkInitializer, $linkTypeProvider, $storeManager, $filterBuilder, $metadataServiceInterface, $extensibleDataObjectConverter, $optionConverter, $fileSystem, $contentValidator, $contentFactory, $mimeTypeExtensionMap, $imageProcessor, $extensionAttributesJoinProcessor);
     }
 
     /**

--- a/Model/DataProvider.php
+++ b/Model/DataProvider.php
@@ -13,6 +13,9 @@ use \Magento\Ui\DataProvider\AbstractDataProvider;
 
 class DataProvider extends AbstractDataProvider
 {
+    // Declare the property explicitly with proper visibility
+    private $loadedData = [];
+
     /**
      * @param string $name
      * @param string $primaryFieldName

--- a/Model/Styla/Api.php
+++ b/Model/Styla/Api.php
@@ -47,7 +47,7 @@ class Api
      */
     protected $_apiConnectionOptions = [
         CURLOPT_RETURNTRANSFER => 1,
-        [
+        CURLOPT_HTTPHEADER => [
             'Accept: application/json',
         ],
     ];
@@ -225,7 +225,7 @@ class Api
         $requestMethod = $request->getConnectionType();
         $requestBody   = '';
 
-        if ($requestMethod == \Zend\Http\Request::METHOD_POST) {
+        if ($requestMethod == \Laminas\Http\Request::METHOD_POST) {
             $requestBody = $request->getParams();
         }
 

--- a/Model/Styla/Api/Request/Type/AbstractType.php
+++ b/Model/Styla/Api/Request/Type/AbstractType.php
@@ -2,7 +2,7 @@
 namespace Styla\Connect2\Model\Styla\Api\Request\Type;
 
 use Styla\Connect2\Api\Styla\RequestInterface as StylaRequestInterface;
-use Zend\Http\Request as HttpRequest;
+use Laminas\Http\Request as HttpRequest;
 
 abstract class AbstractType implements StylaRequestInterface
 {

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ The process of setting up your Content Hub(s) usually goes as follows:
 **Important notes**: 
 * When updating from any previous version to 2.1.0 or higher, please let Styla know beforehand. Your settings need to be updated so that everything works fine.
 * Version 2.2.0 fixes a problem happening on Magento 2.4 and above. If you are switching to this plugin version from any older than 2.1.0 please also let Styla know beforehand and make sure to test Styla content on a stage environment vefore releasing the updates to your production.
+
+[Magento docker documentation](https://github.com/bitnami/containers/tree/69196dec4ecde62d1712ea5b543de7509f49db0e/bitnami/magento#step-1-log-into-the-container-shell-as-root)


### PR DESCRIPTION
Ticket: https://styla.atlassian.net/browse/CMS-1484

Objective:
Support for magento v2.4.7

Changes:
* Remove usage of `$initializationHelper` as mentioned [here](https://github.com/magento/magento2/issues/38669)
* Properly write header
* Change from `Zend` to `Laminas` for `Http\Request` as mentioned [here](https://magento.stackexchange.com/questions/365470/class-zend-http-client-not-found-magento-2-4-6)
* Due to latest php usage, need to declare the property explicitly with proper visibility